### PR TITLE
Updated dox version. Still works.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "dox": "~0.5.3",
     "commander": "~2.5.0",
+    "dox": "^0.6.1",
     "jade": "~1.7.x",
-    "mkdirp": "~0.5.0",
-    "walkdir": "~0.0.7",
     "lodash": "~2.4.1",
-    "marked": "~0.3.2"
+    "marked": "~0.3.2",
+    "mkdirp": "~0.5.0",
+    "walkdir": "~0.0.7"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Looks like npm re-ordered the deps in alphabetical order too.