### PR TITLE
Add jade != to stop html escape

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -123,7 +123,7 @@ html
                       tr
                         td= tag.name
                         td= tag.types
-                        td= tag.description
+                        td!= tag.description
 
             .description !{symbol.description.full} !{symbol.description.extra}
             if symbol.code


### PR DESCRIPTION
Only added to param description because it doesn't happen anywhere else. Closes #58. If dox creates HTML tags anywhere else it might happen.