### PR TITLE
Add condition for return tag

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -124,6 +124,11 @@ html
                         td= tag.name
                         td= tag.types
                         td= tag.description
+                    if tag.type == 'return'
+                      tr
+                        td= tag.type
+                        td= tag.types
+                        td= tag.description
 
             .description !{symbol.description.full} !{symbol.description.extra}
             if symbol.code


### PR DESCRIPTION
This adds the return description to the params options table labeled 'return'. If its wanted somewhere else you would have to extract the tag description on top of the type. Closes #56.