### PR TITLE
add return description to symbol object

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -98,6 +98,7 @@ function _mapSymbol(symbol){
 
   if(returns.length === 1){
     symbol["return"] = returns[0].types.join(' ');
+    symbol["returnDescription"] = returns[0].description.replace(/(<([^>]+)>)/ig, '');
   }
 
   symbol.description.extra = '';

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -78,6 +78,7 @@ function _mapSymbol(symbol){
   var types       = symbol.tags.filter(hasType);
   var description = symbol.tags.filter(hasDescription);
   var returns     = symbol.tags.filter(isReturn);
+  var requires     = symbol.tags.filter(isRequires);
   var jsfiddle    = symbol.tags.filter(hasJSFiddle);
 
   if(symbol.tags.length > 0 && symbol.tags.filter(hasParams).length > 0){
@@ -99,6 +100,13 @@ function _mapSymbol(symbol){
   if(returns.length === 1){
     symbol["return"] = returns[0].types.join(' ');
     symbol["returnDescription"] = returns[0].description.replace(/(<([^>]+)>)/ig, '');
+  }
+
+  if(requires.length !== 0){
+    symbol.requires = [];
+    requires.forEach( function (required) {
+      symbol.requires.push(required.string);
+    })
   }
 
   symbol.description.extra = '';

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -32,6 +32,7 @@ function has(val){
 
 var hasParams      = has('param');
 var isReturn       = has('return');
+var isRequires     = has('requires');
 var hasDescription = has('description');
 var hasType        = has('type');
 var hasJSFiddle    = has('jsFiddle');
@@ -78,7 +79,7 @@ function _mapSymbol(symbol){
   var types       = symbol.tags.filter(hasType);
   var description = symbol.tags.filter(hasDescription);
   var returns     = symbol.tags.filter(isReturn);
-  var requires     = symbol.tags.filter(isRequires);
+  var requires    = symbol.tags.filter(isRequires);
   var jsfiddle    = symbol.tags.filter(hasJSFiddle);
 
   if(symbol.tags.length > 0 && symbol.tags.filter(hasParams).length > 0){


### PR DESCRIPTION
@return description was missing. Also added regex to remove any html as I am using it like this:

```jade
if symbol.return
  table.table.table-bordered.table-striped
    thead
      tr
        th(style="width:20%") Returns
        th Description
    tbody
        tr
          td= symbol.return
          td= symbol.returnDescription
```

Please let me know if you'd like this addition and if you need any changes! 

thanks @FGRibreau!