### PR TITLE
add a space after commas for multiple values

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -122,12 +122,12 @@ html
                     if tag.type == 'param'
                       tr
                         td= tag.name
-                        td= tag.types
+                        td= tag.types.join(', ')
                         td!= tag.description
                     if tag.type == 'return'
                       tr
                         td= tag.type
-                        td= tag.types
+                        td= tag.types.join(', ')
                         td!= tag.description
 
             .description !{symbol.description.full} !{symbol.description.extra}


### PR DESCRIPTION
If tag.types has data like [‘a’, ‘b’] then display it as “a, b” instead of “a,b”. Harmless to single item arrays like [“c”] which would still display like “c”.

Before and after images attached to show the effect. :D

![before](https://cloud.githubusercontent.com/assets/1933203/8764768/2f8844a2-2da2-11e5-94c8-4404662c93d7.png)
![after](https://cloud.githubusercontent.com/assets/1933203/8764769/2f8949ba-2da2-11e5-8376-05b54e4c225c.png)